### PR TITLE
[ACPT-518] Add RootWorkflowExecution from Go sdk patch to fork

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -714,6 +714,15 @@ func (wth *workflowTaskHandlerImpl) createWorkflowContext(task *workflowservice.
 			RunID: attributes.ParentWorkflowExecution.GetRunId(),
 		}
 	}
+
+	var rootWorkflowExecution *WorkflowExecution
+	if attributes.RootWorkflowExecution != nil {
+		rootWorkflowExecution = &WorkflowExecution{
+			ID:    attributes.RootWorkflowExecution.GetWorkflowId(),
+			RunID: attributes.RootWorkflowExecution.GetRunId(),
+		}
+	}
+
 	workflowInfo := &WorkflowInfo{
 		WorkflowExecution: WorkflowExecution{
 			ID:    workflowID,
@@ -735,6 +744,7 @@ func (wth *workflowTaskHandlerImpl) createWorkflowContext(task *workflowservice.
 		ContinuedExecutionRunID:  attributes.ContinuedExecutionRunId,
 		ParentWorkflowNamespace:  attributes.ParentWorkflowNamespace,
 		ParentWorkflowExecution:  parentWorkflowExecution,
+		RootWorkflowExecution:    rootWorkflowExecution,
 		Memo:                     attributes.Memo,
 		SearchAttributes:         attributes.SearchAttributes,
 		RetryPolicy:              convertFromPBRetryPolicy(attributes.RetryPolicy),

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -1234,7 +1234,9 @@ type WorkflowInfo struct {
 	ContinuedExecutionRunID string
 	ParentWorkflowNamespace string
 	ParentWorkflowExecution *WorkflowExecution
-	Memo                    *commonpb.Memo // Value can be decoded using data converter (defaultDataConverter, or custom one if set).
+	// RootWorkflowExecution is the first workflow execution in the chain of workflows. If a workflow is itself a root workflow, then this field is nil.
+	RootWorkflowExecution *WorkflowExecution
+	Memo                  *commonpb.Memo // Value can be decoded using data converter (defaultDataConverter, or custom one if set).
 	// Deprecated: use [Workflow.GetTypedSearchAttributes] instead.
 	SearchAttributes *commonpb.SearchAttributes // Value can be decoded using defaultDataConverter.
 	RetryPolicy      *RetryPolicy


### PR DESCRIPTION
This adds the code from the patch in https://github.com/DataDog/dd-source/pull/273753 to the Temporal Go SDK fork. 
Once we upgrade the Go SDK to v1.35 we will have this functionality as this was added upstream in https://github.com/temporalio/sdk-go/pull/1923. I did not copy the tests from this PR to keep the patch as small as possible and since its already upstream and in the dd-source patch we know it works.

After merge will create and push the annotated tag
```
git tag -a v1.31.0-dd.1 -m 'Tagging v1.31.0-dd.1'
git push origin --tags
```

For use in dd-go & dd-source to fix CI for dd-source customers with workers whose code needs cross repo compile


Development followed https://datadoghq.atlassian.net/wiki/spaces/ATLAS/pages/3630072010/Managing+Forked+Repositories#Development-Occurs-on-Internal-Dev-Branches

Fork maintenance docs: https://datadoghq.atlassian.net/wiki/x/9geCYgE